### PR TITLE
Fix decoding of zero length BerAny type at end of file

### DIFF
--- a/projects/asn1bean/src/main/java/com/beanit/asn1bean/ber/types/BerAny.java
+++ b/projects/asn1bean/src/main/java/com/beanit/asn1bean/ber/types/BerAny.java
@@ -67,7 +67,7 @@ public class BerAny implements Serializable, BerType {
 
     value = new byte[tagLength + lengthLength + lengthField.val];
 
-    if (lengthFiled.val != 0) {
+    if (lengthField.val != 0) {
       Util.readFully(is, value, tagLength + lengthLength, lengthField.val);
     }
     ReverseByteArrayOutputStream os =

--- a/projects/asn1bean/src/main/java/com/beanit/asn1bean/ber/types/BerAny.java
+++ b/projects/asn1bean/src/main/java/com/beanit/asn1bean/ber/types/BerAny.java
@@ -67,7 +67,9 @@ public class BerAny implements Serializable, BerType {
 
     value = new byte[tagLength + lengthLength + lengthField.val];
 
-    Util.readFully(is, value, tagLength + lengthLength, lengthField.val);
+    if (lengthFiled.val != 0) {
+      Util.readFully(is, value, tagLength + lengthLength, lengthField.val);
+    }
     ReverseByteArrayOutputStream os =
         new ReverseByteArrayOutputStream(value, tagLength + lengthLength - 1);
     BerLength.encodeLength(os, lengthField.val);


### PR DESCRIPTION
Util.readFully must be suppressed for the case that we have a zero length value, as it yields "java.io.EOFException: Unexpected end of input stream." when at eof.