### PR TITLE
Add decimal BER REAL decoding

### DIFF
--- a/projects/asn1bean/src/main/java/com/beanit/asn1bean/ber/types/BerReal.java
+++ b/projects/asn1bean/src/main/java/com/beanit/asn1bean/ber/types/BerReal.java
@@ -23,6 +23,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 public class BerReal implements Serializable, BerType {
 
@@ -192,11 +194,25 @@ public class BerReal implements Serializable, BerType {
     byte[] byteCode = new byte[length.val];
     Util.readFully(is, byteCode);
 
-    if ((byteCode[0] & 0x80) != 0x80) {
-      throw new IOException("Only binary REAL encoding is supported");
+    codeLength += length.val;
+
+    byte formatOсtet = byteCode[0];
+    if ((formatOсtet & 0x80) != 0x80) {
+      if (formatOсtet == 0 || (formatOсtet | 0x03) != 0x03) {
+        throw new IOException("Only binary and decimal REAL encoding is supported");
+      }
+
+      byte[] valueBytes = Arrays.copyOfRange(byteCode, 1, byteCode.length);
+      String str = new String(valueBytes, StandardCharsets.US_ASCII);
+      try {
+        value = Double.parseDouble(str.replace(',','.'));
+      } catch(NumberFormatException e) {
+        throw new IOException("Invalid decimal REAL encoding");
+      }
+
+      return codeLength;
     }
 
-    codeLength += length.val;
     int tempLength = 1;
 
     int sign = 1;


### PR DESCRIPTION
8.5.5 Bit 8 of the first contents octet shall be set as follows:
...
b) if bit 8 = 0 and bit 7 = 0, then the decimal encoding specified in 8.5.7 applies;

8.5.7 When decimal encoding is used (bits 8 to 7 = 00), all the contents octets following the first contents octet form
a field, as the term is used in ISO 6093, of a length chosen by the sender, and encoded according to ISO 6093. The
choice of ISO 6093 number representation is specified by bits 6 to 1 of the first contents octet as follows:

Bits 6 to 1 Number representation:
```
00 0001 ISO 6093 NR1 form
00 0010 ISO 6093 NR2 form
00 0011 ISO 6093 NR3 form
```

ISO 6093 simply describes the floating point string representation. NR1 - no decimal separator, NR2 - decimal separator, NR3 - scientific notation. All of these forms can be parsed with parseDouble. The standard allows you to use a comma as a separator, parseDouble is not locale aware, so ',' can be simply replaced with '.'.