### PR TITLE
`gradle build` CI workflow added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build


### PR DESCRIPTION
First of all, thanks for such a great lib!

I've noticed that last pull request #44 contained some formatting issues and gradle build was failing. This commit enables `github actions` in repository, so `gradle build` will be triggered on: 
 - every push to master branch
 - every pull request created to master branch

 Hope this will make life a little bit easier.

And last one, is there any plans to publish version 1.13.1 to maven?
